### PR TITLE
Search State

### DIFF
--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
@@ -9,8 +9,10 @@ sealed class SearchState(
     val endLocation: Location = Location("", Coordinate(0.0, 0.0), "")
 ) {}
 
+// Default search state
 class LaunchState() : SearchState()
 
+// Search state when user has no favorite or recent destinations
 class EmptyInitClickState() : SearchState()
 
 /*
@@ -18,7 +20,6 @@ class EmptyInitClickState() : SearchState()
  * Destinations. **Will be different from EmptyInitSearchState after v.0**
  */
 class InitClickState() : SearchState()
-
 
 // Immediately following InitClickState or EmptyInitClickState when user begins typing.
 class InitSearchState(
@@ -31,7 +32,7 @@ class InitSearchState(
 class RouteDisplayState(
     startLocation: Location,
     endLocation: Location
-) : SearchState(startLocation = startLocation, endLocation = endLocation) {}
+) : SearchState(startLocation, endLocation) {}
 
 /*
  * A clickable bar with Start Location name
@@ -40,7 +41,7 @@ class RouteDisplayState(
 class RouteOptionState(
     startLocation: Location,
     endLocation: Location
-) : SearchState(startLocation = startLocation, endLocation = endLocation) {}
+) : SearchState(startLocation, endLocation) {}
 
 /*
  * In the Route Options state, when the user clicks either the start or end location,
@@ -51,5 +52,3 @@ class ChangeLocationState(
     searchText: String,
     searchedLocations: List<Location>
 ) : SearchState() {}
-
-

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
@@ -1,37 +1,38 @@
 package com.example.ithaca_transit_android_v2.states
 
+import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
-import java.util.*
 
-//Default
-class SearchState
+//Parent Search State Class - Contains Default parameters
+sealed class SearchState(
+    val startLocation: Location = Location("", Coordinate(0.0,0.0),""),
+    val endLocation: Location = Location("", Coordinate(0.0,0.0),"") ,
+    val favDestinations: List<Location> = mutableListOf(),
+    val recentDestinations: List<Location> = mutableListOf()
+){}
 
 //Default UI when launching app. Just displays a search bar (no interactions so far)
-data class LaunchState(
-
-){}
+class LaunchState(
+): SearchState(){}
 
 //First time using the app, after clicking on the search bar, there will be nothing
 //but "Search For a Destination" text and a big magnifying glass
-data class EmptyInitSearchState(
-
-){}
+class EmptyInitSearchState(
+): SearchState(){}
 
 //Click on search bar -> Changes UI by dropping a list of Favorite Destinations and
 //recent destinations
-data class InitSearchState(
-    val favDestinations : List<Location>,
-    val recentDestinations : List<Location>
-){}
-
-
+class InitSearchState(
+    favDestinations : List<Location>,
+    recentDestinations : List<Location>
+): SearchState(favDestinations = favDestinations, recentDestinations = recentDestinations)
 
 //Immediately following InitSearchState when user begins typing. Requires network call
-data class InitNetworkState(
+class InitNetworkState(
     val  searchText : String,
     //Network call to all locations that match the search text
     val  searchedLocations : List<Location>
-){}
+): SearchState(){}
 
 // 2 Possible Ways to get to Route Display State
 // 1)
@@ -43,11 +44,10 @@ data class InitNetworkState(
 // Brings them to the Route Display State -
 // Start Destination name on Left -> Destination name on Right
 // Default start location is Current Location
-data class RouteDisplayState(
-    val startLocation: Location,
-    val endLocation: Location,
-    val date : Date
-){}
+class RouteDisplayState(
+    startLocation: Location,
+    endLocation: Location
+): SearchState(startLocation = startLocation, endLocation = endLocation){}
 
 //How to get to Route Options state
 //1)From Route Display State, click on either the start or end location names
@@ -55,34 +55,24 @@ data class RouteDisplayState(
 //Brings them to the Route Options Menu -
 // 2. A clickable bar with Start Location name - User can click it, but won't make any network calls
 // 3. A clickable bar with Destination name - User can click it, but won't make any network calls
-// 4. Underneath the Search will be populated by Favorite Destinations and Recents
-data class RouteOptionState(
-    val startLocation: Location,
-    val endLocation: Location,
-    val favDestinations : List<Location>,
-    val recentDestinations : List<Location>
+// 4. Underneath the Search will be populated by Favorite Destinations and Recent Destinations
+class RouteOptionState(
+    startLocation: Location,
+    endLocation: Location,
+    favDestinations : List<Location>,
+    recentDestinations : List<Location>
 
-
-){}
+): SearchState(startLocation,endLocation,favDestinations,recentDestinations){}
 
 //In the Route Options state, when the user clicks either the start or end location
 //It automatically creates a black typing field for the User to enter their new
 //desired start or end location name
 //NO Network requirment yet
-data class ChangeLocationState(
+class ChangeLocationState(
     //What the user inputs
-    val searchText : String,
+    searchText : String,
     //Network call to all locations that match the search text
-    val  searchedLocations : List<Location>
-){}
-
-
-//When the User clicks on the clock icon to specify a time they want to leave
-//Creates a pop up that allows user to choose a time for arrival or destination
-data class TimeState(
-    val leaveTime : Time,
-    val arriveTime: Time,
-    val latest : Boolean
-){}
+    searchedLocations : List<Location>
+): SearchState(){}
 
 

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
@@ -3,75 +3,65 @@ package com.example.ithaca_transit_android_v2.states
 import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
 
-//Parent Search State Class - Contains Default parameters
+// Parent Class
 sealed class SearchState(
     val startLocation: Location = Location("", Coordinate(0.0,0.0),""),
-    val endLocation: Location = Location("", Coordinate(0.0,0.0),"") ,
-    val favDestinations: List<Location> = mutableListOf(),
-    val recentDestinations: List<Location> = mutableListOf()
+    val endLocation: Location = Location("", Coordinate(0.0,0.0),"")
 ){}
 
-//Default UI when launching app. Just displays a search bar (no interactions so far)
-class LaunchState(
-): SearchState(){}
 
-//First time using the app, after clicking on the search bar, there will be nothing
-//but "Search For a Destination" text and a big magnifying glass
-class EmptyInitSearchState(
-): SearchState(){}
+// Default UI when launching app - only a search bar (no interactions so far)
 
-//Click on search bar -> Changes UI by dropping a list of Favorite Destinations and
-//recent destinations
+class LaunchState(): SearchState()
+
+// First time launching app then clicking on the search bar, no favorite or recent destinations
+
+class EmptyInitSearchState(): SearchState()
+
+/*
+ Subsequent launches of app the clicking on search bar -> Displays Favorite and Recent
+ Destinations. **Will be different from EmptyInitSearchState after v.0**
+*/
+class InitClickState(): SearchState()
+
+/*
+ Immediately following InitClickState when user begins typing.
+ Requires network call
+*/
 class InitSearchState(
-    favDestinations : List<Location>,
-    recentDestinations : List<Location>
-): SearchState(favDestinations = favDestinations, recentDestinations = recentDestinations)
-
-//Immediately following InitSearchState when user begins typing. Requires network call
-class InitNetworkState(
     val  searchText : String,
     //Network call to all locations that match the search text
     val  searchedLocations : List<Location>
 ): SearchState(){}
 
-// 2 Possible Ways to get to Route Display State
-// 1)
-// After typing in desired location from initial search, user clicks on one of
-// the drop down locations.
-// 2)
-// After successfully setting a start and end location from the route options menu
-//
-// Brings them to the Route Display State -
-// Start Destination name on Left -> Destination name on Right
-// Default start location is Current Location
+/*
+ [Start Destination name on Left] -> [Destination name on Right]
+ Default start location is Current Location
+ */
 class RouteDisplayState(
     startLocation: Location,
     endLocation: Location
 ): SearchState(startLocation = startLocation, endLocation = endLocation){}
 
-//How to get to Route Options state
-//1)From Route Display State, click on either the start or end location names
-//2)Click on a bus stop on map. Automatically fills the start location with the Bus Stop
-//Brings them to the Route Options Menu -
-// 2. A clickable bar with Start Location name - User can click it, but won't make any network calls
-// 3. A clickable bar with Destination name - User can click it, but won't make any network calls
-// 4. Underneath the Search will be populated by Favorite Destinations and Recent Destinations
+
+/*
+ A clickable bar with Start Location name
+ A clickable bar with Destination name
+ No networks have been made yet
+*/
 class RouteOptionState(
     startLocation: Location,
-    endLocation: Location,
-    favDestinations : List<Location>,
-    recentDestinations : List<Location>
+    endLocation: Location
+): SearchState(startLocation = startLocation,endLocation = endLocation){}
 
-): SearchState(startLocation,endLocation,favDestinations,recentDestinations){}
-
-//In the Route Options state, when the user clicks either the start or end location
-//It automatically creates a black typing field for the User to enter their new
-//desired start or end location name
-//NO Network requirment yet
+/*
+ In the Route Options state, when the user clicks either the start or end location
+ It automatically creates a blank typing field for changes
+ Network requirement
+*/
 class ChangeLocationState(
-    //What the user inputs
+    //User Input
     searchText : String,
-    //Network call to all locations that match the search text
     searchedLocations : List<Location>
 ): SearchState(){}
 

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
@@ -9,41 +9,33 @@ sealed class SearchState(
     val endLocation: Location = Location("", Coordinate(0.0, 0.0), "")
 ) {}
 
-// Default UI when launching app - only a search bar (no interactions so far)
 class LaunchState() : SearchState()
 
-// First time launching app then clicking on the search bar, no favorite or recent destinations
-class EmptyInitSearchState() : SearchState()
+class EmptyInitClickState() : SearchState()
 
 /*
- *Subsequent launches of app the clicking on search bar -> Displays Favorite and Recent
- *Destinations. **Will be different from EmptyInitSearchState after v.0**
+ * Subsequent launches of app, then clicking on search bar -> Displays Favorite and Recent
+ * Destinations. **Will be different from EmptyInitSearchState after v.0**
  */
 class InitClickState() : SearchState()
 
-/*
- *Immediately following InitClickState when user begins typing.
- *Requires network call
- */
+
+// Immediately following InitClickState or EmptyInitClickState when user begins typing.
 class InitSearchState(
     val searchText: String,
     // Network call to all locations that match the search text
     val searchedLocations: List<Location>
 ) : SearchState() {}
 
-/*
- *[Start Destination name on Left] -> [Destination name on Right]
- *Default start location is Current Location
- */
+// Default start location is Current Location
 class RouteDisplayState(
     startLocation: Location,
     endLocation: Location
 ) : SearchState(startLocation = startLocation, endLocation = endLocation) {}
 
 /*
- *A clickable bar with Start Location name
- *A clickable bar with Destination name
- *No networks have been made yet
+ * A clickable bar with Start Location name
+ * A clickable bar with Destination name
  */
 class RouteOptionState(
     startLocation: Location,
@@ -51,9 +43,8 @@ class RouteOptionState(
 ) : SearchState(startLocation = startLocation, endLocation = endLocation) {}
 
 /*
- *In the Route Options state, when the user clicks either the start or end location
- *It automatically creates a blank typing field for changes
- *Network requirement
+ * In the Route Options state, when the user clicks either the start or end location,
+ * automatically creating a blank typing field for changes
  */
 class ChangeLocationState(
     // User Input

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
@@ -1,0 +1,88 @@
+package com.example.ithaca_transit_android_v2.states
+
+import com.example.ithaca_transit_android_v2.models.Location
+import java.util.*
+
+//Default
+class SearchState
+
+//Default UI when launching app. Just displays a search bar (no interactions so far)
+data class LaunchState(
+
+){}
+
+//First time using the app, after clicking on the search bar, there will be nothing
+//but "Search For a Destination" text and a big magnifying glass
+data class EmptyInitSearchState(
+
+){}
+
+//Click on search bar -> Changes UI by dropping a list of Favorite Destinations and
+//recent destinations
+data class InitSearchState(
+    val favDestinations : List<Location>,
+    val recentDestinations : List<Location>
+){}
+
+
+
+//Immediately following InitSearchState when user begins typing. Requires network call
+data class InitNetworkState(
+    val  searchText : String,
+    //Network call to all locations that match the search text
+    val  searchedLocations : List<Location>
+){}
+
+// 2 Possible Ways to get to Route Display State
+// 1)
+// After typing in desired location from initial search, user clicks on one of
+// the drop down locations.
+// 2)
+// After successfully setting a start and end location from the route options menu
+//
+// Brings them to the Route Display State -
+// Start Destination name on Left -> Destination name on Right
+// Default start location is Current Location
+data class RouteDisplayState(
+    val startLocation: Location,
+    val endLocation: Location,
+    val date : Date
+){}
+
+//How to get to Route Options state
+//1)From Route Display State, click on either the start or end location names
+//2)Click on a bus stop on map. Automatically fills the start location with the Bus Stop
+//Brings them to the Route Options Menu -
+// 2. A clickable bar with Start Location name - User can click it, but won't make any network calls
+// 3. A clickable bar with Destination name - User can click it, but won't make any network calls
+// 4. Underneath the Search will be populated by Favorite Destinations and Recents
+data class RouteOptionState(
+    val startLocation: Location,
+    val endLocation: Location,
+    val favDestinations : List<Location>,
+    val recentDestinations : List<Location>
+
+
+){}
+
+//In the Route Options state, when the user clicks either the start or end location
+//It automatically creates a black typing field for the User to enter their new
+//desired start or end location name
+//NO Network requirment yet
+data class ChangeLocationState(
+    //What the user inputs
+    val searchText : String,
+    //Network call to all locations that match the search text
+    val  searchedLocations : List<Location>
+){}
+
+
+//When the User clicks on the clock icon to specify a time they want to leave
+//Creates a pop up that allows user to choose a time for arrival or destination
+data class TimeState(
+    val leaveTime : Time,
+    val arriveTime: Time,
+    val latest : Boolean
+){}
+
+

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/SearchState.kt
@@ -5,64 +5,60 @@ import com.example.ithaca_transit_android_v2.models.Location
 
 // Parent Class
 sealed class SearchState(
-    val startLocation: Location = Location("", Coordinate(0.0,0.0),""),
-    val endLocation: Location = Location("", Coordinate(0.0,0.0),"")
-){}
-
+    val startLocation: Location = Location("", Coordinate(0.0, 0.0), ""),
+    val endLocation: Location = Location("", Coordinate(0.0, 0.0), "")
+) {}
 
 // Default UI when launching app - only a search bar (no interactions so far)
-
-class LaunchState(): SearchState()
+class LaunchState() : SearchState()
 
 // First time launching app then clicking on the search bar, no favorite or recent destinations
-
-class EmptyInitSearchState(): SearchState()
-
-/*
- Subsequent launches of app the clicking on search bar -> Displays Favorite and Recent
- Destinations. **Will be different from EmptyInitSearchState after v.0**
-*/
-class InitClickState(): SearchState()
+class EmptyInitSearchState() : SearchState()
 
 /*
- Immediately following InitClickState when user begins typing.
- Requires network call
-*/
+ *Subsequent launches of app the clicking on search bar -> Displays Favorite and Recent
+ *Destinations. **Will be different from EmptyInitSearchState after v.0**
+ */
+class InitClickState() : SearchState()
+
+/*
+ *Immediately following InitClickState when user begins typing.
+ *Requires network call
+ */
 class InitSearchState(
-    val  searchText : String,
-    //Network call to all locations that match the search text
-    val  searchedLocations : List<Location>
-): SearchState(){}
+    val searchText: String,
+    // Network call to all locations that match the search text
+    val searchedLocations: List<Location>
+) : SearchState() {}
 
 /*
- [Start Destination name on Left] -> [Destination name on Right]
- Default start location is Current Location
+ *[Start Destination name on Left] -> [Destination name on Right]
+ *Default start location is Current Location
  */
 class RouteDisplayState(
     startLocation: Location,
     endLocation: Location
-): SearchState(startLocation = startLocation, endLocation = endLocation){}
-
+) : SearchState(startLocation = startLocation, endLocation = endLocation) {}
 
 /*
- A clickable bar with Start Location name
- A clickable bar with Destination name
- No networks have been made yet
-*/
+ *A clickable bar with Start Location name
+ *A clickable bar with Destination name
+ *No networks have been made yet
+ */
 class RouteOptionState(
     startLocation: Location,
     endLocation: Location
-): SearchState(startLocation = startLocation,endLocation = endLocation){}
+) : SearchState(startLocation = startLocation, endLocation = endLocation) {}
 
 /*
- In the Route Options state, when the user clicks either the start or end location
- It automatically creates a blank typing field for changes
- Network requirement
-*/
+ *In the Route Options state, when the user clicks either the start or end location
+ *It automatically creates a blank typing field for changes
+ *Network requirement
+ */
 class ChangeLocationState(
-    //User Input
-    searchText : String,
-    searchedLocations : List<Location>
-): SearchState(){}
+    // User Input
+    searchText: String,
+    searchedLocations: List<Location>
+) : SearchState() {}
 
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" --> 
Created classes that represent all states that Search Bar can be in


## Overview

<!-- Summarize your changes here. -->
Created a sealed parent class that was inherited by all sub search state classes. 

NOTE - I chose to not utilize data classes when creating the states because it required that all parameters be instantiated with a val/var. This would then require me to use 'override' when inheriting, however, I can't do so because the parent class SearchState is defaulted to final. If I were to change SearchState to open, it wouldn't allow me to make SearchState sealed. 



## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
`SearchState` - Parent Search State Class - Contains Default parameters
`LaunchState` - Default UI when launching app. Just displays a search bar (no interactions so far)

'EmptyInitSearchState` - First time using the app, after clicking on the search bar, there will be nothing but "Search For a Destination" text and a big magnifying glass

`InitClickState` - Click on search bar -> Changes UI by dropping a list of Favorite Destinations and
recent destinations

`InitSearchState` - Immediately following InitClickState when user begins typing. Requires network call

`RouteDisplayState`  - 
2 Possible Ways to get to Route Display State
1)
After typing in desired location from initial search, user clicks on one ofthe drop down locations.
2)
 After successfully setting a start and end location from the route options menu
Brings them to the Route Display State -
Start Destination name on Left -> Destination name on Right
Default start location is Current Location

`RouteOptionState` - 
How to get to Route Options state
1)From Route Display State, click on either the start or end location names
2)Click on a bus stop on map. Automatically fills the start location with the Bus Stop

Brings them to the Route Options Menu -
1. A clickable bar with Start Location name - User can click it, but won't make any network calls
2. A clickable bar with Destination name - User can click it, but won't make any network calls
3. Underneath the Search will be populated by Favorite Destinations and Recent Destinations

`ChangeLocationState` - 
In the Route Options state, when the user clicks either the start or end location
It automatically creates a black typing field for the User to enter their new
Desired start or end location name
**NOTE** - on the commit, it will say no networking call here, but I decided that it will





## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. --> None Yet



## Next Steps (delete if not applicable)

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. --> Fix these states after to be more optimal when coding
