### PR TITLE
Committing a changed Route class and MapState class

### DIFF
--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
@@ -12,7 +12,7 @@ class LaunchState():MapState(emptyList())
 
 //State that represents the map with all bus stops marked and marks the user's current location.
 class LaunchStateFilled(
-    busStops: List<Coordinate>,
+    busStops: List<Location>,
     currentLocation: Coordinate
 ): MapState(emptyList())
 

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
@@ -1,0 +1,33 @@
+package com.example.ithaca_transit_android_v2.Models
+
+import com.example.ithaca_transit_android_v2.models.Coordinate
+import com.example.ithaca_transit_android_v2.models.Location
+sealed class MapState(
+    val trip:Trip = Trip(
+        emptyList(),
+        Location("", Coordinate(0.0, 0.0), ""),
+        Location("", Coordinate(0.0, 0.0), ""),
+        false,
+        null,
+        null,
+        0)
+) {}
+
+class LaunchState():MapState()
+
+class LaunchStateFilled(
+    busStops: List<Coordinate>
+): MapState()
+
+class DestinationSearch():MapState() {}
+
+class TripOptions(
+    firstBusTrip: Trip,
+    walkingTrip: Trip
+): MapState(){}
+
+class SelectedTrip(
+    selectedTrip: Trip
+):MapState(
+    selectedTrip
+){}

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
@@ -2,24 +2,25 @@ package com.example.ithaca_transit_android_v2.Models
 
 import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
+import java.util.*
+
 sealed class MapState(
     val trip:Trip = Trip(
         emptyList(),
         Location("", Coordinate(0.0, 0.0), ""),
         Location("", Coordinate(0.0, 0.0), ""),
         false,
-        null,
-        null,
+        Date(0),
+        Date(0),
         0)
 ) {}
 
 class LaunchState():MapState()
-
 class LaunchStateFilled(
     busStops: List<Coordinate>
 ): MapState()
 
-class DestinationSearch():MapState() {}
+class BusStopsShown():MapState() {}
 
 class TripOptions(
     firstBusTrip: Trip,

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
@@ -2,33 +2,25 @@ package com.example.ithaca_transit_android_v2.Models
 
 import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
-import java.util.*
+import java.util.Date
 
 sealed class MapState(
-    val trip:Trip = Trip(
-        emptyList(),
-        Location("", Coordinate(0.0, 0.0), ""),
-        Location("", Coordinate(0.0, 0.0), ""),
-        false,
-        Date(0),
-        Date(0),
-        0)
-) {}
+    trips: List<Trip>
+)
 
-class LaunchState():MapState()
+class LaunchState():MapState(emptyList())
+
 class LaunchStateFilled(
     busStops: List<Coordinate>
-): MapState()
+): MapState(emptyList())
 
-class BusStopsShown():MapState() {}
+class BusStopsShown():MapState(emptyList())
 
 class TripOptions(
     firstBusTrip: Trip,
     walkingTrip: Trip
-): MapState(){}
+): MapState(listOf(firstBusTrip, walkingTrip))
 
 class SelectedTrip(
     selectedTrip: Trip
-):MapState(
-    selectedTrip
-){}
+):MapState(listOf(selectedTrip))

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Models/MapState.kt
@@ -7,20 +7,22 @@ import java.util.Date
 sealed class MapState(
     trips: List<Trip>
 )
-
+//State that represents the empty map before a network call has been
 class LaunchState():MapState(emptyList())
 
+//State that represents the map with all bus stops marked and marks the user's current location.
 class LaunchStateFilled(
-    busStops: List<Coordinate>
+    busStops: List<Coordinate>,
+    currentLocation: Coordinate
 ): MapState(emptyList())
 
-class BusStopsShown():MapState(emptyList())
-
+//state that shows the first trip option and the walking trip.
 class TripOptions(
     firstBusTrip: Trip,
     walkingTrip: Trip
 ): MapState(listOf(firstBusTrip, walkingTrip))
 
+//state that shows just selected path
 class SelectedTrip(
     selectedTrip: Trip
 ):MapState(listOf(selectedTrip))

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Models/Route.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Models/Route.kt
@@ -4,11 +4,11 @@ import com.example.ithaca_transit_android_v2.models.Location
 import java.util.*
 
 data class Route(
-    val listOfCoordinates: Array<Coordinate>,
+    val listOfCoordinates: List<Coordinate>,
     val startTime: Date,
     val endTime: Date,
     val startLocation: Location,
     val endLocation: Location,
-    val busStops: Array<Location>,
+    val busStops: List<Location>,
     val busNumber: Int
 ) {}


### PR DESCRIPTION
## Overview

I created and file out the `Map State` class. I added four states to represent UI changes and network calls. The states are:
1. `LaunchState` which is a blank map before any network calls are made. This is the map without any route drawn on or bus stops marked. 
2. `BusStopsShown` is a state that is launched the very first time the app is opened after the `LaunchState`. It shows all the bus stops in Ithaca. 
3. `TripOptions` is the state shown after the user selected a destination. It shows the first bus route and a walking route. 
4. `SelectedTrip` is the state that shows the visual representation of the chosen trip. 

## Changes Made
The MapState classes were added, and the Arrays in Route were changed to Lists. 



## Next Steps (delete if not applicable)
Not entirely sure if MapState includes the correct fields. It might need to Trip objects to account for the RouteObjects state. Furthermore, I need to figure what the map will display when the person is already on the bus. The map will have to show a shortening path most likely.


