### PR TITLE
RouteCard.kt implemented for the route card states

### DIFF
--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Models/Trip.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Models/Trip.kt
@@ -1,5 +1,8 @@
 package com.example.ithaca_transit_android_v2.Models
 
+import com.example.ithaca_transit_android_v2.models.Location
+import java.util.*
+
 // [Trip] is a collection of [Route] objects and other essential information
 // to represent a way of getting to the destination
 data class Trip (

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/RouteCard.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/RouteCard.kt
@@ -1,0 +1,4 @@
+package com.example.ithaca_transit_android_v2.states
+
+class RouteCard {
+}

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/states/RouteCard.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/states/RouteCard.kt
@@ -1,4 +1,89 @@
 package com.example.ithaca_transit_android_v2.states
 
-class RouteCard {
-}
+import com.example.ithaca_transit_android_v2.Models.Route
+import com.example.ithaca_transit_android_v2.models.Coordinate
+import com.example.ithaca_transit_android_v2.models.Location
+import java.util.*
+
+// Parent Class
+sealed class RouteCard (
+    val routes: List<Route> = emptyList(),
+    val startLocation: Location = Location("", Coordinate(0.0,0.0),""),
+    val endLocation: Location = Location("", Coordinate(0.0,0.0),""),
+    val isWalkingOnly: Boolean = false,
+    val arrival: Date = Date(0),
+    val depart: Date = Date(0),
+    val boardInMin: Int = 0
+){}
+
+/* Route cards at the bottom of launch screen
+   Bus number displayed is obtained from [routes]
+   Keeping all the parameters here to be safe,
+   but in practice some might not be needed
+*/
+class LaunchCardState(
+    routes: List<Route>,
+    startLocation: Location,
+    endLocation: Location,
+    isWalkingOnly: Boolean,
+    arrival: Date,
+    depart: Date,
+    boardInMin: Int
+): RouteCard(
+    routes = routes,
+    startLocation = startLocation,
+    endLocation = endLocation,
+    isWalkingOnly = isWalkingOnly,
+    arrival = arrival,
+    depart = depart,
+    boardInMin = boardInMin
+)
+
+// A route card at launch screen is clicked
+class LaunchCardClickedState(): RouteCard()
+
+// A default display of a route card in route option view
+// [isWalkingOnly] and number of [routes] affects the drawing of transit details
+class CardFoldedDisplayState(
+    routes: List<Route>,
+    startLocation: Location,
+    endLocation: Location,
+    isWalkingOnly: Boolean,
+    arrival: Date,
+    depart: Date,
+    boardInMin: Int
+): RouteCard(
+    routes = routes,
+    startLocation = startLocation,
+    endLocation = endLocation,
+    isWalkingOnly = isWalkingOnly,
+    arrival = arrival,
+    depart = depart,
+    boardInMin = boardInMin
+)
+
+// A route card at route option screen is clicked
+class OptionCardClickedState(): RouteCard()
+
+// [CardDetailDisplayState] is the state for the route detail view
+// Used when a card at either launch screen or route options is clicked
+class CardDetailDisplayState(
+    routes: List<Route>,
+    startLocation: Location,
+    endLocation: Location,
+    isWalkingOnly: Boolean,
+    arrival: Date,
+    depart: Date,
+    boardInMin: Int
+): RouteCard(
+    routes = routes,
+    startLocation = startLocation,
+    endLocation = endLocation,
+    isWalkingOnly = isWalkingOnly,
+    arrival = arrival,
+    depart = depart,
+    boardInMin = boardInMin
+)
+
+// User clicks on the [Leave Now] button in route detail view and leave at dialog pops up
+class LeaveAtClickedState: RouteCard()


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

This pull request includes an added import statement to `Trip.kt` to fix the error with `Date` and a newly created `RouteCard.kt` class for route card states.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
The `RouteCard.kt` includes the following states:

**Launch screen:**
* `LaunchCardState` for displaying folded cards at the bottom
*  `LaunchCardClickedState` for when those cards are clicked

**Route options:**
* `CardFoldedDisplayState` for displaying folded cards in route options screen
* `OptionCardClickedState` for when those cards are clicked

**Detail screen:**
* `CardDetailDisplayState` for displaying trip details in the detail screen
* `LeaveAtClickedState` for when `Leave Now` button is clicked in detail screen

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
No testing made