### PR TITLE
Haichen/route networking2

### DIFF
--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -3,6 +3,7 @@ package com.example.ithaca_transit_android_v2
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.networking.NetworkUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,15 +16,23 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        val end = Coordinate(42.444971674516864, -76.48098092526197)
+        val uid = "E4A0256E-5865-4E9F-8A5A-33747CAC7EBF"
+        val time = 1573515642.318114
+        val destinationName = "Bill & Melinda Gates Hall"
+        val start = Coordinate(42.44717985041025, -76.48551732274225)
+        val arriveBy = false
 
         // TODO (lesley): just for testing purposes - replace with rxjava
+
         runBlocking {
             val deferred = CoroutineScope(Dispatchers.IO).async {
-                NetworkUtils().getAllBusStops()
+                NetworkUtils().getRouteOptions(end, uid, time, destinationName, start, arriveBy)
             }.await()
 
             Log.d("testing-final", deferred.toString())
+
         }
-        //
+
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.example.ithaca_transit_android_v2.models.Coordinate
-import com.example.ithaca_transit_android_v2.networking.NetworkUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -19,7 +19,15 @@ class MainActivity : AppCompatActivity() {
         // TODO (lesley): just for testing purposes - replace with rxjava
         runBlocking {
             val deferred = CoroutineScope(Dispatchers.IO).async {
-                NetworkUtils().getAllBusStops()
+                NetworkUtils().getRouteOptions("{\n" +
+                        "  \"end\" : \"42.444971674516864,-76.48098092526197\",\n" +
+                        "  \"uid\" : \"E4A0256E-5865-4E9F-8A5A-33747CAC7EBF\",\n" +
+                        "  \"time\" : 1573515642.318114,\n" +
+                        "  \"destinationName\" : \"Bill & Melinda Gates Hall\",\n" +
+                        "  \"start\" : \"42.44717985041025,-76.48551732274225\",\n" +
+                        "  \"arriveBy\" : false,\n" +
+                        "  \"originName\" : \"Current Location\"\n" +
+                        "}")
             }.await()
 
             Log.d("testing-final", deferred.toString())

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -15,13 +15,14 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // ======== FOR TESTING ONLY ========
         val end = Coordinate(42.444971674516864, -76.48098092526197)
-//        val uid = "E4A0256E-5865-4E9F-8A5A-33747CAC7EBF"
+        // val uid = "E4A0256E-5865-4E9F-8A5A-33747CAC7EBF"
         val time = 1574292741.0
         val destinationName = "Bill & Melinda Gates Hall"
         val start = Coordinate(42.44717985041025, -76.48551732274225)
         val arriveBy = false
-
 
         // TODO (lesley): just for testing purposes - replace with rxjava
         runBlocking {
@@ -29,9 +30,8 @@ class MainActivity : AppCompatActivity() {
                 NetworkUtils().getRouteOptions(start, end, time, arriveBy, destinationName)
             }.await()
 
+            // Printing out [deferred] in log for testing
             printLongLog(deferred.toString())
-
-
         }
     }
 

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -17,7 +17,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         val end = Coordinate(42.444971674516864, -76.48098092526197)
-        val uid = "E4A0256E-5865-4E9F-8A5A-33747CAC7EBF"
+//        val uid = "E4A0256E-5865-4E9F-8A5A-33747CAC7EBF"
         val time = 1573515642.318114
         val destinationName = "Bill & Melinda Gates Hall"
         val start = Coordinate(42.44717985041025, -76.48551732274225)
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
         // TODO (lesley): just for testing purposes - replace with rxjava
         runBlocking {
             val deferred = CoroutineScope(Dispatchers.IO).async {
-                NetworkUtils().getRouteOptions(end, uid, time, destinationName, start, arriveBy)
+                NetworkUtils().getRouteOptions(start, end, time, arriveBy, destinationName)
             }.await()
             Log.d("testing-final", deferred.toString())
         }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -23,7 +23,15 @@ class MainActivity : AppCompatActivity() {
         val start = Coordinate(42.44717985041025, -76.48551732274225)
         val arriveBy = false
 
+
+        // TODO (lesley): just for testing purposes - replace with rxjava
+        runBlocking {
+            val deferred = CoroutineScope(Dispatchers.IO).async {
+                NetworkUtils().getRouteOptions(end, uid, time, destinationName, start, arriveBy)
+            }.await()
+            Log.d("testing-final", deferred.toString())
         }
 
     }
+}
 

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -18,7 +18,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         val end = Coordinate(42.444971674516864, -76.48098092526197)
 //        val uid = "E4A0256E-5865-4E9F-8A5A-33747CAC7EBF"
-        val time = 1573515642.318114
+        val time = 1574292741.0
         val destinationName = "Bill & Melinda Gates Hall"
         val start = Coordinate(42.44717985041025, -76.48551732274225)
         val arriveBy = false
@@ -29,9 +29,20 @@ class MainActivity : AppCompatActivity() {
             val deferred = CoroutineScope(Dispatchers.IO).async {
                 NetworkUtils().getRouteOptions(start, end, time, arriveBy, destinationName)
             }.await()
-            Log.d("testing-final", deferred.toString())
-        }
 
+
+            val maxLogSize = 1000
+            val stringLength = deferred.toString()?.length
+            if (stringLength != null) {
+                for (i in 0..stringLength / maxLogSize) {
+                    val start = i * maxLogSize
+                    var end = (i + 1) * maxLogSize
+                    end = if (end > deferred.toString().length) deferred.toString().length else end
+                    Log.v("returnBody", deferred.toString().substring(start, end))
+                }
+            }
+
+        }
     }
 }
 

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/MainActivity.kt
@@ -29,18 +29,22 @@ class MainActivity : AppCompatActivity() {
                 NetworkUtils().getRouteOptions(start, end, time, arriveBy, destinationName)
             }.await()
 
+            printLongLog(deferred.toString())
 
-            val maxLogSize = 1000
-            val stringLength = deferred.toString()?.length
-            if (stringLength != null) {
-                for (i in 0..stringLength / maxLogSize) {
-                    val start = i * maxLogSize
-                    var end = (i + 1) * maxLogSize
-                    end = if (end > deferred.toString().length) deferred.toString().length else end
-                    Log.v("returnBody", deferred.toString().substring(start, end))
-                }
+
+        }
+    }
+
+    private fun printLongLog (s: String) {
+        val maxLogSize = 1000
+        val stringLength = s.length
+        if (stringLength != null) {
+            for (i in 0..stringLength / maxLogSize) {
+                val start = i * maxLogSize
+                var end = (i + 1) * maxLogSize
+                end = if (end > s.length) s.length else end
+                Log.v("returnBody", s.substring(start, end))
             }
-
         }
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -76,7 +76,7 @@ class NetworkUtils {
             .add(KotlinJsonAdapterFactory())
             .build()
 
-        val adapter: JsonAdapter<RouteOptions> = moshi.adapter(type)
+A        val adapter: JsonAdapter<RouteOptions> = moshi.adapter(type)
         return adapter.fromJson(body) ?: RouteOptions(emptyList(), emptyList(), emptyList())
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -2,6 +2,7 @@ package com.example.ithaca_transit_android_v2.networking
 
 import com.example.ithaca_transit_android_v2.LocationAdapter
 import com.example.ithaca_transit_android_v2.RouteAdapter
+import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
 import com.example.ithaca_transit_android_v2.models.RouteOptions
 import com.squareup.moshi.JsonAdapter
@@ -13,6 +14,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
+import java.util.Date
 
 /*
  * NetworkUtils include all the networking calls needed
@@ -60,9 +62,25 @@ class NetworkUtils {
         return adapter.fromJson(body) ?: emptyList()
     }
 
-    fun getRouteOptions(query: String): RouteOptions {
+    fun getRouteOptions(
+        end: Coordinate,
+        uid: String,
+        // Temporarily a string until we figure out how to pass a date object correctly
+        time: Double,
+        destName : String,
+        start : Coordinate,
+        arriveBy: Boolean,
+        originName: String = "Current Location" ): RouteOptions {
+
+
         val json = JSONObject()
-        json.put("query", query)
+        json.put("end", end.toString())
+        json.put("uid", uid)
+        json.put("time", time)
+        json.put("destinationName", destName)
+        json.put("start", start.toString())
+        json.put("arriveBy", arriveBy)
+        json.put("originName", originName)
         val requestBody = json.toString().toRequestBody(mediaType)
         val request: Request = Request.Builder()
             .url(url + "route")

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -1,6 +1,5 @@
 package com.example.ithaca_transit_android_v2
 
-import android.util.Log
 import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
 import com.example.ithaca_transit_android_v2.models.RouteOptions
@@ -82,10 +81,8 @@ class NetworkUtils {
             .build()
 
         val body = client.newCall(request).execute().body?.string()
-        Log.d("testing", body)
         val response = JSONObject(body)
         val arr = response.get("data")
-        Log.d("testing", arr.toString())
 
         val type = newParameterizedType(RouteOptions::class.java)
         val moshi = Moshi.Builder()

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -3,7 +3,7 @@ package com.example.ithaca_transit_android_v2.networking
 import android.util.Log
 import com.example.ithaca_transit_android_v2.CustomDateAdapter
 import com.example.ithaca_transit_android_v2.LocationAdapter
-import com.example.ithaca_transit_android_v2.RouteAdapter
+//import com.example.ithaca_transit_android_v2.RouteAdapter
 import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
 import com.example.ithaca_transit_android_v2.models.RouteOptions
@@ -66,54 +66,41 @@ class NetworkUtils {
     }
 
     fun getRouteOptions(
+        start: Coordinate,
         end: Coordinate,
-        uid: String,
-        // Temporarily a string until we figure out how to pass a date object correctly
         time: Double,
-        destName : String,
-        start : Coordinate,
-        arriveBy: Boolean,
-        originName: String = "Current Location" ): RouteOptions {
-
+        arriveBy: Boolean = true,
+        destName : String
+    ): RouteOptions {
 
         val json = JSONObject()
-        json.put("end", end.toString())
-        json.put("uid", uid)
-        json.put("time", time)
-        json.put("destinationName", destName)
         json.put("start", start.toString())
+        json.put("end", end.toString())
+        json.put("time", time)
         json.put("arriveBy", arriveBy)
-        json.put("originName", originName)
-
+        json.put("destinationName", destName)
 
         val requestBody = json.toString().toRequestBody(mediaType)
-        Log.d("ReqBody", json.toString())
         val request: Request = Request.Builder()
             .url(url + "route")
             .post(requestBody)
             .build()
 
         val body = client.newCall(request).execute().body?.string()
-
-        val maxLogSize = 1000
-        val stringLength = body?.length
-        if (stringLength != null) {
-            for (i in 0..stringLength / maxLogSize) {
-                val start = i * maxLogSize
-                var end = (i + 1) * maxLogSize
-                end = if (end > body.length) body.length else end
-                Log.v("request", body.substring(start, end))
-            }
-        }
+        Log.d("testing", body)
+        val response = JSONObject(body)
+        val arr = response.get("data")
+        Log.d("testing", arr.toString())
 
         val type = newParameterizedType(RouteOptions::class.java)
         val moshi = Moshi.Builder()
-            .add(RouteAdapter())
-            .add(KotlinJsonAdapterFactory())
             .add(CustomDateAdapter())
+            .add(KotlinJsonAdapterFactory())
             .build()
-
+//
         val adapter: JsonAdapter<RouteOptions> = moshi.adapter(type)
-        return adapter.fromJson(body) ?: RouteOptions(emptyList(), emptyList(), emptyList())
+
+        return adapter.fromJson(arr.toString()) ?: RouteOptions(emptyList(), emptyList(), emptyList())
+//        return RouteOptions(emptyList(), emptyList(), emptyList())
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -3,6 +3,7 @@ package com.example.ithaca_transit_android_v2.networking
 import android.util.Log
 import com.example.ithaca_transit_android_v2.CustomDateAdapter
 import com.example.ithaca_transit_android_v2.LocationAdapter
+import com.example.ithaca_transit_android_v2.RouteAdapter
 //import com.example.ithaca_transit_android_v2.RouteAdapter
 import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
@@ -95,6 +96,7 @@ class NetworkUtils {
         val type = newParameterizedType(RouteOptions::class.java)
         val moshi = Moshi.Builder()
             .add(CustomDateAdapter())
+            .add(RouteAdapter())
             .add(KotlinJsonAdapterFactory())
             .build()
 //

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -1,24 +1,18 @@
-package com.example.ithaca_transit_android_v2.networking
+package com.example.ithaca_transit_android_v2
 
 import android.util.Log
-import com.example.ithaca_transit_android_v2.CustomDateAdapter
-import com.example.ithaca_transit_android_v2.LocationAdapter
-import com.example.ithaca_transit_android_v2.RouteAdapter
-//import com.example.ithaca_transit_android_v2.RouteAdapter
 import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
 import com.example.ithaca_transit_android_v2.models.RouteOptions
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types.newParameterizedType
-import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
-import java.util.Date
 
 /*
  * NetworkUtils include all the networking calls needed
@@ -99,10 +93,9 @@ class NetworkUtils {
             .add(RouteAdapter())
             .add(KotlinJsonAdapterFactory())
             .build()
-//
+
         val adapter: JsonAdapter<RouteOptions> = moshi.adapter(type)
 
         return adapter.fromJson(arr.toString()) ?: RouteOptions(emptyList(), emptyList(), emptyList())
-//        return RouteOptions(emptyList(), emptyList(), emptyList())
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -1,5 +1,7 @@
 package com.example.ithaca_transit_android_v2.networking
 
+import android.util.Log
+import com.example.ithaca_transit_android_v2.CustomDateAdapter
 import com.example.ithaca_transit_android_v2.LocationAdapter
 import com.example.ithaca_transit_android_v2.RouteAdapter
 import com.example.ithaca_transit_android_v2.models.Coordinate
@@ -8,6 +10,7 @@ import com.example.ithaca_transit_android_v2.models.RouteOptions
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types.newParameterizedType
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -81,17 +84,33 @@ class NetworkUtils {
         json.put("start", start.toString())
         json.put("arriveBy", arriveBy)
         json.put("originName", originName)
+
+
         val requestBody = json.toString().toRequestBody(mediaType)
+        Log.d("ReqBody", json.toString())
         val request: Request = Request.Builder()
             .url(url + "route")
             .post(requestBody)
             .build()
 
         val body = client.newCall(request).execute().body?.string()
+
+        val maxLogSize = 1000
+        val stringLength = body?.length
+        if (stringLength != null) {
+            for (i in 0..stringLength / maxLogSize) {
+                val start = i * maxLogSize
+                var end = (i + 1) * maxLogSize
+                end = if (end > body.length) body.length else end
+                Log.v("request", body.substring(start, end))
+            }
+        }
+
         val type = newParameterizedType(RouteOptions::class.java)
         val moshi = Moshi.Builder()
             .add(RouteAdapter())
             .add(KotlinJsonAdapterFactory())
+            .add(CustomDateAdapter())
             .build()
 
         val adapter: JsonAdapter<RouteOptions> = moshi.adapter(type)

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -57,4 +57,8 @@ class NetworkUtils {
         val adapter: JsonAdapter<List<Location>> = moshi.adapter(type)
         return adapter.fromJson(body) ?: emptyList()
     }
+
+    fun getRouteOptions() {
+        
+    }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkUtils.kt
@@ -1,7 +1,9 @@
 package com.example.ithaca_transit_android_v2.networking
 
 import com.example.ithaca_transit_android_v2.LocationAdapter
+import com.example.ithaca_transit_android_v2.RouteAdapter
 import com.example.ithaca_transit_android_v2.models.Location
+import com.example.ithaca_transit_android_v2.models.RouteOptions
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types.newParameterizedType
@@ -58,7 +60,23 @@ class NetworkUtils {
         return adapter.fromJson(body) ?: emptyList()
     }
 
-    fun getRouteOptions() {
-        
+    fun getRouteOptions(query: String): RouteOptions {
+        val json = JSONObject()
+        json.put("query", query)
+        val requestBody = json.toString().toRequestBody(mediaType)
+        val request: Request = Request.Builder()
+            .url(url + "route")
+            .post(requestBody)
+            .build()
+
+        val body = client.newCall(request).execute().body?.string()
+        val type = newParameterizedType(RouteOptions::class.java)
+        val moshi = Moshi.Builder()
+            .add(RouteAdapter())
+            .add(KotlinJsonAdapterFactory())
+            .build()
+
+        val adapter: JsonAdapter<RouteOptions> = moshi.adapter(type)
+        return adapter.fromJson(body) ?: RouteOptions(emptyList(), emptyList(), emptyList())
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -1,11 +1,13 @@
 package com.example.ithaca_transit_android_v2
 
-import com.example.ithaca_transit_android_v2.models.Coordinate
-import com.example.ithaca_transit_android_v2.models.Location
-import com.example.ithaca_transit_android_v2.models.LocationType
+import com.example.ithaca_transit_android_v2.models.*
 import com.squareup.moshi.FromJson
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.ToJson
+import java.text.SimpleDateFormat
+import java.util.*
+import java.util.concurrent.TimeUnit
 
 @JsonClass(generateAdapter = true)
 class LocationAdapter {
@@ -43,5 +45,129 @@ class LocationAdapter {
             )
         }
         return DataLocation(final)
+    }
+}
+
+@JsonClass(generateAdapter = true)
+class RouteAdapter {
+    class DataRoute(
+        val data: DataRouteOptions
+    )
+
+    @JsonClass(generateAdapter = true)
+    class DataRouteOptions(
+        val fromStop: List<JsonRoute>,
+        val walking: List<JsonRoute>,
+        val boardingSoon: List<JsonRoute>
+    )
+
+    @JsonClass(generateAdapter = true)
+    class JsonRoute(
+        @Json(name = "directions")
+        val directions: List<JsonDirection>,
+        @Json(name = "startCoords")
+        val startLocation: JsonLocation,
+        @Json(name = "endCoords")
+        val endLocation: JsonLocation,
+        // TODO: need to calculate isWalkingOnly
+        @Json(name = "arrivalTime")
+        val arrival: String, // e.g. 2019-11-06T17:07:20Z
+        @Json(name = "departureTime")
+        val depart: String
+        // TODO: need to calculate BoardInMin
+    )
+
+    @JsonClass(generateAdapter = true)
+    class JsonDirection(
+        @Json(name = "path")
+        val listOfCoordinates: List<Coordinate>,
+        @Json(name = "startTime")
+        val startTime: String,
+        @Json(name = "endTime")
+        val endTime: String,
+        @Json(name = "startLocation")
+        val startLocation: JsonLocation,
+        @Json(name = "endLocation")
+        val endLocation: JsonLocation,
+        @Json(name = "stops")
+        val busStops: List<JsonLocation>,
+        @Json(name = "routeNumber")
+        val busNumber: Int
+    )
+
+    @JsonClass(generateAdapter = true)
+    class JsonLocation(
+        val type: LocationType,
+        val name: String,
+        val lat: Double,
+        val long: Double,
+        val detail: String?
+    )
+
+    @FromJson
+    private fun fromJson(json: DataRoute) : RouteOptions {
+        fun processStringDate(dateString: String): Date {
+            val inputFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'")
+            return inputFormatter.parse(dateString)
+        }
+
+        fun processStops(locs: List<JsonLocation>): List<Location> {
+            return locs.map{ loc -> Location(LocationType.BUS_STOP, loc.name,
+                Coordinate(loc.lat, loc.long), loc.detail)}
+        }
+
+        fun processDirections(jsonDirection: List<JsonDirection>): List<Direction> {
+            return jsonDirection.map { dir -> Direction(
+                dir.listOfCoordinates.map { c -> Coordinate(c.latitude, c.longitude) },
+                processStringDate(dir.startTime),
+                processStringDate(dir.endTime),
+                Coordinate(dir.startLocation.lat, dir.startLocation.long),
+                Coordinate(dir.endLocation.lat, dir.endLocation.long),
+                processStops(dir.busStops),
+                dir.busNumber
+            )}
+        }
+
+        fun computeBoardInMin(firstBusDirection: Direction): Int {
+            val diff =  firstBusDirection.startTime.time - Calendar.getInstance().time.time
+            return TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS).toInt()
+        }
+
+        fun processRoutesBus(jsonRoute: List<JsonRoute>): List<Route> {
+            return jsonRoute.map { route -> Route(
+                processDirections(route.directions),
+                Coordinate(route.startLocation.lat, route.startLocation.long),
+                Coordinate(route.endLocation.lat, route.endLocation.long),
+                false,
+                processStringDate(route.arrival),
+                processStringDate(route.depart),
+                computeBoardInMin(processDirections(route.directions)[1])
+                // index [1] is accessed because the second direction is the first bus direction
+            ) }
+        }
+
+        fun processRoutesWalk(jsonRoute: List<JsonRoute>): List<Route> {
+            return jsonRoute.map { route -> Route(
+                processDirections(route.directions),
+                Coordinate(route.startLocation.lat, route.startLocation.long),
+                Coordinate(route.endLocation.lat, route.endLocation.long),
+                true,
+                processStringDate(route.arrival),
+                processStringDate(route.depart),
+                0   // [boardInMin] for a walking route is set to be 0
+            ) }
+        }
+
+        return RouteOptions(
+            processRoutesBus(json.data.fromStop),
+            processRoutesWalk(json.data.walking),
+            processRoutesBus(json.data.boardingSoon)
+        )
+    }
+
+    @ToJson
+    private fun toJson (routeOpt: RouteOptions): DataRoute{
+        // TODO: this function hasn't been implemented
+        return DataRoute(DataRouteOptions(emptyList(), emptyList(), emptyList()))
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -6,7 +6,8 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.ToJson
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Date
 import java.util.concurrent.TimeUnit
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -17,7 +17,6 @@ class LocationAdapter {
     class DataLocation(
         val data: List<JsonLocation>
     )
-
     @JsonClass(generateAdapter = true)
     class JsonLocation(
         val type: LocationType,
@@ -26,7 +25,6 @@ class LocationAdapter {
         val long: Double,
         val detail: String?
     )
-
     @FromJson
     private fun fromJson(json: DataLocation): List<Location> {
         val finalLoc = json.data.map { loc ->
@@ -34,7 +32,6 @@ class LocationAdapter {
         }
         return finalLoc
     }
-
     @ToJson
     private fun toJson(json: List<Location>): DataLocation {
         val final = json.map { loc ->
@@ -49,9 +46,6 @@ class LocationAdapter {
         return DataLocation(final)
     }
 }
-
-
-
 class RouteAdapter{
     class JsonRoute(
         val directions: List<Direction>,
@@ -62,45 +56,23 @@ class RouteAdapter{
         @Json(name ="departureTime")
         val depart: Date
     )
-
     @FromJson
     private fun fromJson(json: JsonRoute): Route {
-
-        var firstBus = 0
-        var boardInMins = 0
-        if(json.directions[0].type != DirectionType.BUS){
-            firstBus = 1
-        }
-        if(json.directions.size != 1){
-            boardInMins = Route.computeBoardInMin(json.directions[firstBus])
-        }
-
+        var firstBus = if (json.directions[0].type == DirectionType.BUS) 1 else 0
+        var boardInMins: Int = if (json.directions.size != 1) Route.computeBoardInMin(json.directions[firstBus]) else 0
         return Route(json.directions, json.startCoords, json.endCoords, json.arrival, json.depart,
             boardInMins)
     }
-
-    @ToJson
-    private fun toJson(route: Route): JsonRoute {
-        return JsonRoute(emptyList(), Coordinate(0.0,0.0),
-            Coordinate(0.0,0.0), Calendar.getInstance().time,
-            Calendar.getInstance().time)
-    }
-
 }
-
 class CustomDateAdapter{
     private val serverFormat = ("yyyy-MM-dd'T'HH:mm:ss'Z'")
     private val dateFormat = SimpleDateFormat(serverFormat, Locale.getDefault())
-
     @FromJson
     fun fromJson(date: String): Date {
         return dateFormat.parse(date)
     }
-
     @ToJson
     fun toJson(writer: JsonWriter, value: Date?) {
-        if (value != null) {
-            writer.value(value.toString())
-        }
+        value?.let { writer.value(value.toString()) }
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -1,10 +1,7 @@
 package com.example.ithaca_transit_android_v2
 
 import com.example.ithaca_transit_android_v2.models.*
-import com.squareup.moshi.FromJson
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
-import com.squareup.moshi.ToJson
+import com.squareup.moshi.*
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -56,9 +53,13 @@ class RouteAdapter {
 
     @JsonClass(generateAdapter = true)
     class DataRouteOptions(
+        @Json(name = "boardingSoon")
+        val boardingSoon: List<JsonRoute>,
+        @Json(name = "fromStop")
         val fromStop: List<JsonRoute>,
-        val walking: List<JsonRoute>,
-        val boardingSoon: List<JsonRoute>
+        @Json(name = "walking")
+        val walking: List<JsonRoute>
+
     )
 
     @JsonClass(generateAdapter = true)
@@ -107,8 +108,8 @@ class RouteAdapter {
     @FromJson
     private fun fromJson(json: DataRoute) : RouteOptions {
         fun processStringDate(dateString: String): Date {
-            val inputFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'")
-            return inputFormatter.parse(dateString)
+            val dateAdapt = CustomDateAdapter()
+            return dateAdapt.fromJson(dateString)
         }
 
         fun processStops(locs: List<JsonLocation>): List<Location> {
@@ -159,9 +160,10 @@ class RouteAdapter {
         }
 
         return RouteOptions(
+            processRoutesBus(json.data.boardingSoon),
             processRoutesBus(json.data.fromStop),
-            processRoutesWalk(json.data.walking),
-            processRoutesBus(json.data.boardingSoon)
+            processRoutesWalk(json.data.walking)
+
         )
     }
 
@@ -169,5 +171,25 @@ class RouteAdapter {
     private fun toJson (routeOpt: RouteOptions): DataRoute{
         // TODO: this function hasn't been implemented
         return DataRoute(DataRouteOptions(emptyList(), emptyList(), emptyList()))
+    }
+}
+
+class CustomDateAdapter{
+    private val dateFormat = SimpleDateFormat(SERVER_FORMAT, Locale.getDefault())
+
+    @FromJson
+    fun fromJson(date: String): Date {
+        return dateFormat.parse(date)
+    }
+
+    @ToJson
+    fun toJson(writer: JsonWriter, value: Date?) {
+        if (value != null) {
+            writer.value(value.toString())
+        }
+    }
+
+    companion object {
+        const val SERVER_FORMAT = ("yyyy-MM-dd'T'HH:mm:ss'Z'") // define your server format here
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -1,10 +1,15 @@
 package com.example.ithaca_transit_android_v2
 
 import com.example.ithaca_transit_android_v2.models.*
-import com.squareup.moshi.*
-import java.lang.IndexOutOfBoundsException
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonWriter
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
+import java.util.Calendar
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 @JsonClass(generateAdapter = true)
@@ -32,7 +37,6 @@ class LocationAdapter {
 
     @ToJson
     private fun toJson(json: List<Location>): DataLocation {
-
         val final = json.map { loc ->
             JsonLocation(
                 loc.type,
@@ -57,7 +61,6 @@ class RouteAdapter{
         val arrival: Date,
         @Json(name ="departureTime")
         val depart: Date
-
     )
 
     @FromJson
@@ -76,144 +79,18 @@ class RouteAdapter{
             boardInMins = computeBoardInMin(json.directions[firstBus])
         }
 
-        return Route(json.directions, json.startCoords, json.endCoords, json.arrival, json.depart, boardInMins )
-
-
+        return Route(json.directions, json.startCoords, json.endCoords, json.arrival, json.depart,
+            boardInMins)
     }
 
     @ToJson
     private fun toJson(route: Route): JsonRoute {
-        return JsonRoute(emptyList(), Coordinate(0.0,0.0),Coordinate(0.0,0.0), Calendar.getInstance().time, Calendar.getInstance().time )
-
+        return JsonRoute(emptyList(), Coordinate(0.0,0.0),
+            Coordinate(0.0,0.0), Calendar.getInstance().time,
+            Calendar.getInstance().time)
     }
 
-
 }
-
-//
-//@JsonClass(generateAdapter = true)
-//class RouteAdapter {
-//    class DataRoute(
-//        val data: DataRouteOptions
-//    )
-//
-//    @JsonClass(generateAdapter = true)
-//    class DataRouteOptions(
-//        @Json(name = "boardingSoon")
-//        val boardingSoon: List<JsonRoute>,
-//        @Json(name = "fromStop")
-//        val fromStop: List<JsonRoute>,
-//        @Json(name = "walking")
-//        val walking: List<JsonRoute>
-//
-//    )
-//
-////    @JsonClass(generateAdapter = true)
-////    class JsonRoute(
-////        @Json(name = "directions")
-////        val directions: List<JsonDirection>,
-////        @Json(name = "startCoords")
-////        val startCoords: JsonCoordinate,
-////        @Json(name = "endCoords")
-////        val endCoords: JsonCoordinate,
-////        // TODO: need to calculate isWalkingOnly
-////        @Json(name = "arrivalTime")
-////        val arrival: String, // e.g. 2019-11-06T17:07:20Z
-////        @Json(name = "departureTime")
-////        val depart: String
-////        // TODO: need to calculate BoardInMin
-////    )
-//
-////    @JsonClass(generateAdapter = true)
-////    class JsonDirection(
-////        @Json(name = "path")
-////        val listOfCoordinates: List<JsonCoordinate>,
-////        @Json(name = "startTime")
-////        val startTime: String,
-////        @Json(name = "endTime")
-////        val endTime: String,
-////        @Json(name = "startLocation")
-////        val startCoords: JsonCoordinate,
-////        @Json(name = "endLocation")
-////        val endCoords: JsonCoordinate,
-////        @Json(name = "stops")
-////        val busStops: List<JsonLocation>,
-////        @Json(name = "routeNumber")
-////        val busNumber: Int
-////    )
-//
-//    @FromJson
-//    private fun fromJson(json: DataRoute) : RouteOptions {
-//        fun processStringDate(dateString: String): Date {
-//            val dateAdapt = CustomDateAdapter()
-//            return dateAdapt.fromJson(dateString)
-//        }
-//
-//        fun processStops(locs: List<JsonLocation>): List<Location> {
-//            return locs.map{ loc -> Location(LocationType.BUS_STOP, loc.name,
-//                Coordinate(loc.lat, loc.long), loc.detail)}
-//        }
-//
-//        fun processCoord (coord: JsonCoordinate): Coordinate {
-//            return Coordinate(coord.latitude, coord.longitude)
-//        }
-//
-//        fun processDirections(jsonDirection: List<JsonDirection>): List<Direction> {
-//            return jsonDirection.map { dir -> Direction(
-//                dir.listOfCoordinates.map { c -> processCoord(c) },
-//                processStringDate(dir.startTime),
-//                processStringDate(dir.endTime),
-//                processCoord(dir.startCoords),
-//                processCoord(dir.startCoords),
-//                processStops(dir.busStops),
-//                dir.busNumber
-//            )}
-//        }
-//
-//        fun computeBoardInMin(firstBusDirection: Direction): Int {
-//            val diff =  firstBusDirection.startTime.time - Calendar.getInstance().time.time
-//            return TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS).toInt()
-//        }
-//
-//        fun processRoutesBus(jsonRoute: List<JsonRoute>): List<Route> {
-//            return jsonRoute.map { route -> Route(
-//                processDirections(route.directions),
-//                processCoord(route.startCoords),
-//                processCoord(route.endCoords),
-//                false,
-//                processStringDate(route.arrival),
-//                processStringDate(route.depart),
-//                computeBoardInMin(processDirections(route.directions)[1])
-//                // index [1] is accessed because the second direction is the first bus direction
-//            ) }
-//        }
-//
-//        fun processRoutesWalk(jsonRoute: List<JsonRoute>): List<Route> {
-//            return jsonRoute.map { route -> Route(
-//                processDirections(route.directions),
-//                processCoord(route.startCoords),
-//                processCoord(route.endCoords),
-//                true,
-//                processStringDate(route.arrival),
-//                processStringDate(route.depart),
-//                0   // [boardInMin] for a walking route is set to be 0
-//            ) }
-//        }
-//
-//        return RouteOptions(
-//            processRoutesBus(json.data.boardingSoon),
-//            processRoutesBus(json.data.fromStop),
-//            processRoutesWalk(json.data.walking)
-//
-//        )
-//    }
-//
-//    @ToJson
-//    private fun toJson (routeOpt: RouteOptions): DataRoute{
-//        // TODO: this function hasn't been implemented
-//        return DataRoute(DataRouteOptions(emptyList(), emptyList(), emptyList()))
-//    }
-//}
 
 class CustomDateAdapter{
     private val dateFormat = SimpleDateFormat(SERVER_FORMAT, Locale.getDefault())

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -45,146 +45,134 @@ class LocationAdapter {
     }
 }
 
-@JsonClass(generateAdapter = true)
-class RouteAdapter {
-    class DataRoute(
-        val data: DataRouteOptions
-    )
+class DirectionAdapter {
 
-    @JsonClass(generateAdapter = true)
-    class DataRouteOptions(
-        @Json(name = "boardingSoon")
-        val boardingSoon: List<JsonRoute>,
-        @Json(name = "fromStop")
-        val fromStop: List<JsonRoute>,
-        @Json(name = "walking")
-        val walking: List<JsonRoute>
 
-    )
-
-    @JsonClass(generateAdapter = true)
-    class JsonRoute(
-        @Json(name = "directions")
-        val directions: List<JsonDirection>,
-        @Json(name = "startCoords")
-        val startCoords: JsonCoordinate,
-        @Json(name = "endCoords")
-        val endCoords: JsonCoordinate,
-        // TODO: need to calculate isWalkingOnly
-        @Json(name = "arrivalTime")
-        val arrival: String, // e.g. 2019-11-06T17:07:20Z
-        @Json(name = "departureTime")
-        val depart: String
-        // TODO: need to calculate BoardInMin
-    )
-
-    @JsonClass(generateAdapter = true)
-    class JsonDirection(
-        @Json(name = "path")
-        val listOfCoordinates: List<JsonCoordinate>,
-        @Json(name = "startTime")
-        val startTime: String,
-        @Json(name = "endTime")
-        val endTime: String,
-        @Json(name = "startLocation")
-        val startCoords: JsonCoordinate,
-        @Json(name = "endLocation")
-        val endCoords: JsonCoordinate,
-        @Json(name = "stops")
-        val busStops: List<JsonLocation>,
-        @Json(name = "routeNumber")
-        val busNumber: Int
-    )
-
-    @JsonClass(generateAdapter = true)
-    class JsonCoordinate(
-        @Json(name = "lat")
-        val latitude: Double,
-        @Json(name = "long")
-        val longitude: Double
-    )
-
-    @JsonClass(generateAdapter = true)
-    class JsonLocation(
-        val type: LocationType,
-        val name: String,
-        val lat: Double,
-        val long: Double,
-        val detail: String?
-    )
-
-    @FromJson
-    private fun fromJson(json: DataRoute) : RouteOptions {
-        fun processStringDate(dateString: String): Date {
-            val dateAdapt = CustomDateAdapter()
-            return dateAdapt.fromJson(dateString)
-        }
-
-        fun processStops(locs: List<JsonLocation>): List<Location> {
-            return locs.map{ loc -> Location(LocationType.BUS_STOP, loc.name,
-                Coordinate(loc.lat, loc.long), loc.detail)}
-        }
-
-        fun processCoord (coord: JsonCoordinate): Coordinate {
-            return Coordinate(coord.latitude, coord.longitude)
-        }
-
-        fun processDirections(jsonDirection: List<JsonDirection>): List<Direction> {
-            return jsonDirection.map { dir -> Direction(
-                dir.listOfCoordinates.map { c -> processCoord(c) },
-                processStringDate(dir.startTime),
-                processStringDate(dir.endTime),
-                processCoord(dir.startCoords),
-                processCoord(dir.startCoords),
-                processStops(dir.busStops),
-                dir.busNumber
-            )}
-        }
-
-        fun computeBoardInMin(firstBusDirection: Direction): Int {
-            val diff =  firstBusDirection.startTime.time - Calendar.getInstance().time.time
-            return TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS).toInt()
-        }
-
-        fun processRoutesBus(jsonRoute: List<JsonRoute>): List<Route> {
-            return jsonRoute.map { route -> Route(
-                processDirections(route.directions),
-                processCoord(route.startCoords),
-                processCoord(route.endCoords),
-                false,
-                processStringDate(route.arrival),
-                processStringDate(route.depart),
-                computeBoardInMin(processDirections(route.directions)[1])
-                // index [1] is accessed because the second direction is the first bus direction
-            ) }
-        }
-
-        fun processRoutesWalk(jsonRoute: List<JsonRoute>): List<Route> {
-            return jsonRoute.map { route -> Route(
-                processDirections(route.directions),
-                processCoord(route.startCoords),
-                processCoord(route.endCoords),
-                true,
-                processStringDate(route.arrival),
-                processStringDate(route.depart),
-                0   // [boardInMin] for a walking route is set to be 0
-            ) }
-        }
-
-        return RouteOptions(
-            processRoutesBus(json.data.boardingSoon),
-            processRoutesBus(json.data.fromStop),
-            processRoutesWalk(json.data.walking)
-
-        )
-    }
-
-    @ToJson
-    private fun toJson (routeOpt: RouteOptions): DataRoute{
-        // TODO: this function hasn't been implemented
-        return DataRoute(DataRouteOptions(emptyList(), emptyList(), emptyList()))
-    }
 }
+//
+//@JsonClass(generateAdapter = true)
+//class RouteAdapter {
+//    class DataRoute(
+//        val data: DataRouteOptions
+//    )
+//
+//    @JsonClass(generateAdapter = true)
+//    class DataRouteOptions(
+//        @Json(name = "boardingSoon")
+//        val boardingSoon: List<JsonRoute>,
+//        @Json(name = "fromStop")
+//        val fromStop: List<JsonRoute>,
+//        @Json(name = "walking")
+//        val walking: List<JsonRoute>
+//
+//    )
+//
+////    @JsonClass(generateAdapter = true)
+////    class JsonRoute(
+////        @Json(name = "directions")
+////        val directions: List<JsonDirection>,
+////        @Json(name = "startCoords")
+////        val startCoords: JsonCoordinate,
+////        @Json(name = "endCoords")
+////        val endCoords: JsonCoordinate,
+////        // TODO: need to calculate isWalkingOnly
+////        @Json(name = "arrivalTime")
+////        val arrival: String, // e.g. 2019-11-06T17:07:20Z
+////        @Json(name = "departureTime")
+////        val depart: String
+////        // TODO: need to calculate BoardInMin
+////    )
+//
+////    @JsonClass(generateAdapter = true)
+////    class JsonDirection(
+////        @Json(name = "path")
+////        val listOfCoordinates: List<JsonCoordinate>,
+////        @Json(name = "startTime")
+////        val startTime: String,
+////        @Json(name = "endTime")
+////        val endTime: String,
+////        @Json(name = "startLocation")
+////        val startCoords: JsonCoordinate,
+////        @Json(name = "endLocation")
+////        val endCoords: JsonCoordinate,
+////        @Json(name = "stops")
+////        val busStops: List<JsonLocation>,
+////        @Json(name = "routeNumber")
+////        val busNumber: Int
+////    )
+//
+//    @FromJson
+//    private fun fromJson(json: DataRoute) : RouteOptions {
+//        fun processStringDate(dateString: String): Date {
+//            val dateAdapt = CustomDateAdapter()
+//            return dateAdapt.fromJson(dateString)
+//        }
+//
+//        fun processStops(locs: List<JsonLocation>): List<Location> {
+//            return locs.map{ loc -> Location(LocationType.BUS_STOP, loc.name,
+//                Coordinate(loc.lat, loc.long), loc.detail)}
+//        }
+//
+//        fun processCoord (coord: JsonCoordinate): Coordinate {
+//            return Coordinate(coord.latitude, coord.longitude)
+//        }
+//
+//        fun processDirections(jsonDirection: List<JsonDirection>): List<Direction> {
+//            return jsonDirection.map { dir -> Direction(
+//                dir.listOfCoordinates.map { c -> processCoord(c) },
+//                processStringDate(dir.startTime),
+//                processStringDate(dir.endTime),
+//                processCoord(dir.startCoords),
+//                processCoord(dir.startCoords),
+//                processStops(dir.busStops),
+//                dir.busNumber
+//            )}
+//        }
+//
+//        fun computeBoardInMin(firstBusDirection: Direction): Int {
+//            val diff =  firstBusDirection.startTime.time - Calendar.getInstance().time.time
+//            return TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS).toInt()
+//        }
+//
+//        fun processRoutesBus(jsonRoute: List<JsonRoute>): List<Route> {
+//            return jsonRoute.map { route -> Route(
+//                processDirections(route.directions),
+//                processCoord(route.startCoords),
+//                processCoord(route.endCoords),
+//                false,
+//                processStringDate(route.arrival),
+//                processStringDate(route.depart),
+//                computeBoardInMin(processDirections(route.directions)[1])
+//                // index [1] is accessed because the second direction is the first bus direction
+//            ) }
+//        }
+//
+//        fun processRoutesWalk(jsonRoute: List<JsonRoute>): List<Route> {
+//            return jsonRoute.map { route -> Route(
+//                processDirections(route.directions),
+//                processCoord(route.startCoords),
+//                processCoord(route.endCoords),
+//                true,
+//                processStringDate(route.arrival),
+//                processStringDate(route.depart),
+//                0   // [boardInMin] for a walking route is set to be 0
+//            ) }
+//        }
+//
+//        return RouteOptions(
+//            processRoutesBus(json.data.boardingSoon),
+//            processRoutesBus(json.data.fromStop),
+//            processRoutesWalk(json.data.walking)
+//
+//        )
+//    }
+//
+//    @ToJson
+//    private fun toJson (routeOpt: RouteOptions): DataRoute{
+//        // TODO: this function hasn't been implemented
+//        return DataRoute(DataRouteOptions(emptyList(), emptyList(), emptyList()))
+//    }
+//}
 
 class CustomDateAdapter{
     private val dateFormat = SimpleDateFormat(SERVER_FORMAT, Locale.getDefault())

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -65,10 +65,6 @@ class RouteAdapter{
 
     @FromJson
     private fun fromJson(json: JsonRoute): Route {
-        fun computeBoardInMin(firstBusDirection: Direction): Int {
-            val diff = firstBusDirection.startTime.time - Calendar.getInstance().time.time
-            return TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS).toInt()
-        }
 
         var firstBus = 0
         var boardInMins = 0
@@ -76,7 +72,7 @@ class RouteAdapter{
             firstBus = 1
         }
         if(json.directions.size != 1){
-            boardInMins = computeBoardInMin(json.directions[firstBus])
+            boardInMins = Route.computeBoardInMin(json.directions[firstBus])
         }
 
         return Route(json.directions, json.startCoords, json.endCoords, json.arrival, json.depart,
@@ -93,7 +89,8 @@ class RouteAdapter{
 }
 
 class CustomDateAdapter{
-    private val dateFormat = SimpleDateFormat(SERVER_FORMAT, Locale.getDefault())
+    private val serverFormat = ("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private val dateFormat = SimpleDateFormat(serverFormat, Locale.getDefault())
 
     @FromJson
     fun fromJson(date: String): Date {
@@ -105,9 +102,5 @@ class CustomDateAdapter{
         if (value != null) {
             writer.value(value.toString())
         }
-    }
-
-    companion object {
-        const val SERVER_FORMAT = ("yyyy-MM-dd'T'HH:mm:ss'Z'") // define your server format here
     }
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -3,8 +3,7 @@ package com.example.ithaca_transit_android_v2
 import com.example.ithaca_transit_android_v2.models.*
 import com.squareup.moshi.*
 import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -66,9 +66,9 @@ class RouteAdapter {
         @Json(name = "directions")
         val directions: List<JsonDirection>,
         @Json(name = "startCoords")
-        val startLocation: JsonLocation,
+        val startCoords: JsonCoordinate,
         @Json(name = "endCoords")
-        val endLocation: JsonLocation,
+        val endCoords: JsonCoordinate,
         // TODO: need to calculate isWalkingOnly
         @Json(name = "arrivalTime")
         val arrival: String, // e.g. 2019-11-06T17:07:20Z
@@ -80,19 +80,27 @@ class RouteAdapter {
     @JsonClass(generateAdapter = true)
     class JsonDirection(
         @Json(name = "path")
-        val listOfCoordinates: List<Coordinate>,
+        val listOfCoordinates: List<JsonCoordinate>,
         @Json(name = "startTime")
         val startTime: String,
         @Json(name = "endTime")
         val endTime: String,
         @Json(name = "startLocation")
-        val startLocation: JsonLocation,
+        val startCoords: JsonCoordinate,
         @Json(name = "endLocation")
-        val endLocation: JsonLocation,
+        val endCoords: JsonCoordinate,
         @Json(name = "stops")
         val busStops: List<JsonLocation>,
         @Json(name = "routeNumber")
         val busNumber: Int
+    )
+
+    @JsonClass(generateAdapter = true)
+    class JsonCoordinate(
+        @Json(name = "lat")
+        val latitude: Double,
+        @Json(name = "long")
+        val longitude: Double
     )
 
     @JsonClass(generateAdapter = true)
@@ -116,13 +124,17 @@ class RouteAdapter {
                 Coordinate(loc.lat, loc.long), loc.detail)}
         }
 
+        fun processCoord (coord: JsonCoordinate): Coordinate {
+            return Coordinate(coord.latitude, coord.longitude)
+        }
+
         fun processDirections(jsonDirection: List<JsonDirection>): List<Direction> {
             return jsonDirection.map { dir -> Direction(
-                dir.listOfCoordinates.map { c -> Coordinate(c.latitude, c.longitude) },
+                dir.listOfCoordinates.map { c -> processCoord(c) },
                 processStringDate(dir.startTime),
                 processStringDate(dir.endTime),
-                Coordinate(dir.startLocation.lat, dir.startLocation.long),
-                Coordinate(dir.endLocation.lat, dir.endLocation.long),
+                processCoord(dir.startCoords),
+                processCoord(dir.startCoords),
                 processStops(dir.busStops),
                 dir.busNumber
             )}
@@ -136,8 +148,8 @@ class RouteAdapter {
         fun processRoutesBus(jsonRoute: List<JsonRoute>): List<Route> {
             return jsonRoute.map { route -> Route(
                 processDirections(route.directions),
-                Coordinate(route.startLocation.lat, route.startLocation.long),
-                Coordinate(route.endLocation.lat, route.endLocation.long),
+                processCoord(route.startCoords),
+                processCoord(route.endCoords),
                 false,
                 processStringDate(route.arrival),
                 processStringDate(route.depart),
@@ -149,8 +161,8 @@ class RouteAdapter {
         fun processRoutesWalk(jsonRoute: List<JsonRoute>): List<Route> {
             return jsonRoute.map { route -> Route(
                 processDirections(route.directions),
-                Coordinate(route.startLocation.lat, route.startLocation.long),
-                Coordinate(route.endLocation.lat, route.endLocation.long),
+                processCoord(route.startCoords),
+                processCoord(route.endCoords),
                 true,
                 processStringDate(route.arrival),
                 processStringDate(route.depart),

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/NetworkingAdapters.kt
@@ -2,6 +2,7 @@ package com.example.ithaca_transit_android_v2
 
 import com.example.ithaca_transit_android_v2.models.*
 import com.squareup.moshi.*
+import java.lang.IndexOutOfBoundsException
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -45,10 +46,50 @@ class LocationAdapter {
     }
 }
 
-class DirectionAdapter {
+
+
+class RouteAdapter{
+    class JsonRoute(
+        val directions: List<Direction>,
+        val startCoords: Coordinate,
+        val endCoords: Coordinate,
+        @Json(name ="arrivalTime")
+        val arrival: Date,
+        @Json(name ="departureTime")
+        val depart: Date
+
+    )
+
+    @FromJson
+    private fun fromJson(json: JsonRoute): Route {
+        fun computeBoardInMin(firstBusDirection: Direction): Int {
+            val diff = firstBusDirection.startTime.time - Calendar.getInstance().time.time
+            return TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS).toInt()
+        }
+
+        var firstBus = 0
+        var boardInMins = 0
+        if(json.directions[0].type != DirectionType.BUS){
+            firstBus = 1
+        }
+        if(json.directions.size != 1){
+            boardInMins = computeBoardInMin(json.directions[firstBus])
+        }
+
+        return Route(json.directions, json.startCoords, json.endCoords, json.arrival, json.depart, boardInMins )
+
+
+    }
+
+    @ToJson
+    private fun toJson(route: Route): JsonRoute {
+        return JsonRoute(emptyList(), Coordinate(0.0,0.0),Coordinate(0.0,0.0), Calendar.getInstance().time, Calendar.getInstance().time )
+
+    }
 
 
 }
+
 //
 //@JsonClass(generateAdapter = true)
 //class RouteAdapter {

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Coordinate.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Coordinate.kt
@@ -4,4 +4,7 @@ package com.example.ithaca_transit_android_v2.models
 data class Coordinate(
     val latitude: Double,
     val longitude: Double
-)
+){
+    override fun toString(): String = "$latitude, $longitude"
+}
+

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Coordinate.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Coordinate.kt
@@ -1,8 +1,12 @@
 package com.example.ithaca_transit_android_v2.models
 
+import com.squareup.moshi.Json
+
 //Coordinate.kt - Represents the longitude and latitude of a Location
 data class Coordinate(
+    @Json(name = "lat")
     val latitude: Double,
+    @Json(name = "long")
     val longitude: Double
 ){
     override fun toString(): String = "$latitude, $longitude"

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
@@ -5,8 +5,8 @@ data class Direction(
     val listOfCoordinates: List<Coordinate>,
     val startTime: Date,
     val endTime: Date,
-    val startLocation: Coordinate,
-    val endLocation: Coordinate,
+    val startCoords: Coordinate,
+    val endCoords: Coordinate,
     val busStops: List<Location>,
     val busNumber: Int
 )

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
@@ -5,8 +5,8 @@ data class Direction(
     val listOfCoordinates: List<Coordinate>,
     val startTime: Date,
     val endTime: Date,
-    val startLocation: Location,
-    val endLocation: Location,
+    val startLocation: Coordinate,
+    val endLocation: Coordinate,
     val busStops: List<Location>,
     val busNumber: Int
 )

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
@@ -1,12 +1,20 @@
 package com.example.ithaca_transit_android_v2.models
-import java.util.*
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.util.Date
 
+@JsonClass(generateAdapter = true)
 data class Direction(
+    @Json(name = "path")
     val listOfCoordinates: List<Coordinate>,
     val startTime: Date,
     val endTime: Date,
+    @Json(name = "startLocation")
     val startCoords: Coordinate,
+    @Json(name = "endLocation")
     val endCoords: Coordinate,
-    val busStops: List<Location>,
-    val busNumber: Int
+    @Json(name = "stops")
+    val busStops: List<Any>,
+    @Json(name = "routeNumber")
+    val busNumber: Int?
 )

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
@@ -14,7 +14,7 @@ data class Direction(
     @Json(name = "endLocation")
     val endCoords: Coordinate,
     @Json(name = "stops")
-    val busStops: List<Any>,
+    val busStops: List<Stop>,
     @Json(name = "routeNumber")
     val busNumber: Int?
 )

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Direction.kt
@@ -5,6 +5,7 @@ import java.util.Date
 
 @JsonClass(generateAdapter = true)
 data class Direction(
+    val type : DirectionType,
     @Json(name = "path")
     val listOfCoordinates: List<Coordinate>,
     val startTime: Date,

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/DirectionType.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/DirectionType.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.Json
 /*
 Represents the type of route that is displayed on the map
  */
-enum class RouteType {
+enum class DirectionType {
     @Json(name = "depart")
     BUS,
     @Json(name = "walk")

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/DirectionType.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/DirectionType.kt
@@ -1,9 +1,13 @@
 package com.example.ithaca_transit_android_v2.models
 
+import com.squareup.moshi.Json
+
 /*
 Represents the type of route that is displayed on the map
  */
 enum class RouteType {
+    @Json(name = "depart")
     BUS,
+    @Json(name = "walk")
     WALK
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
@@ -11,10 +11,9 @@ data class Route (
     val directions: List<Direction>,
     val startCoords: Coordinate,
     val endCoords: Coordinate,
-//    val isWalkingOnly: Boolean,
     @Json(name ="arrivalTime")
     val arrival: Date,
     @Json(name ="departureTime")
-    val depart: Date
-//    val boardInMin: Int
+    val depart: Date,
+    val boardInMin: Int
 )

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
@@ -2,7 +2,8 @@ package com.example.ithaca_transit_android_v2.models
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import java.util.*
+import java.util.Date
+import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
 // [Route] is a collection of [Direction] objects and other essential information

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
@@ -1,5 +1,6 @@
 package com.example.ithaca_transit_android_v2.models
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.Date
 
@@ -10,8 +11,10 @@ data class Route (
     val directions: List<Direction>,
     val startCoords: Coordinate,
     val endCoords: Coordinate,
-    val isWalkingOnly: Boolean,
+//    val isWalkingOnly: Boolean,
+    @Json(name ="arrivalTime")
     val arrival: Date,
-    val depart: Date,
-    val boardInMin: Int
+    @Json(name ="departureTime")
+    val depart: Date
+//    val boardInMin: Int
 )

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
@@ -1,13 +1,15 @@
 package com.example.ithaca_transit_android_v2.models
 
+import com.squareup.moshi.JsonClass
 import java.util.Date
 
 // [Route] is a collection of [Direction] objects and other essential information
 // to represent a way of getting to the destination
+@JsonClass(generateAdapter = true)
 data class Route (
     val directions: List<Direction>,
-    val startLocation: Location,
-    val endLocation: Location,
+    val startLocation: Coordinate,
+    val endLocation: Coordinate,
     val isWalkingOnly: Boolean,
     val arrival: Date,
     val depart: Date,

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
@@ -2,7 +2,8 @@ package com.example.ithaca_transit_android_v2.models
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import java.util.Date
+import java.util.*
+import java.util.concurrent.TimeUnit
 
 // [Route] is a collection of [Direction] objects and other essential information
 // to represent a way of getting to the destination
@@ -16,4 +17,11 @@ data class Route (
     @Json(name ="departureTime")
     val depart: Date,
     val boardInMin: Int
-)
+) {
+    companion object {
+        fun computeBoardInMin(firstBusDirection: Direction): Int {
+            val diff = firstBusDirection.startTime.time - Calendar.getInstance().time.time
+            return TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS).toInt()
+        }
+    }
+}

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Route.kt
@@ -8,8 +8,8 @@ import java.util.Date
 @JsonClass(generateAdapter = true)
 data class Route (
     val directions: List<Direction>,
-    val startLocation: Coordinate,
-    val endLocation: Coordinate,
+    val startCoords: Coordinate,
+    val endCoords: Coordinate,
     val isWalkingOnly: Boolean,
     val arrival: Date,
     val depart: Date,

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/RouteOptions.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/RouteOptions.kt
@@ -1,11 +1,18 @@
 package com.example.ithaca_transit_android_v2.models
 
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
 /*
  * [RouteOptions] is a collection of three groups of route objects
  * (fromStop, walking and boardingSoon) for the RouteOptions view
  */
+@JsonClass(generateAdapter = true)
 data class RouteOptions (
+    @Json(name = "boardingSoon")
+    val boardingSoon: List<Route>,
+    @Json(name = "fromStop")
     val fromStop: List<Route>,
-    val walking: List<Route>,
-    val boardingSoon: List<Route>
+    @Json(name = "walking")
+    val walking: List<Route>
 ){}

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/RouteOptions.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/RouteOptions.kt
@@ -1,0 +1,11 @@
+package com.example.ithaca_transit_android_v2.models
+
+/*
+ * [RouteOptions] is a collection of three groups of route objects
+ * (fromStop, walking and boardingSoon) for the RouteOptions view
+ */
+data class RouteOptions (
+    val fromStop: List<Route>,
+    val walking: List<Route>,
+    val boardingSoon: List<Route>
+){}

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/RouteOptions.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/RouteOptions.kt
@@ -9,10 +9,7 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class RouteOptions (
-    @Json(name = "boardingSoon")
     val boardingSoon: List<Route>,
-    @Json(name = "fromStop")
     val fromStop: List<Route>,
-    @Json(name = "walking")
     val walking: List<Route>
-){}
+)

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Stop.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Stop.kt
@@ -1,0 +1,11 @@
+package com.example.ithaca_transit_android_v2.models
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+//Location. - Represents either a bus stop or a google place.
+@JsonClass(generateAdapter = true)
+// TODO: deprecate this class 
+data class Stop(
+    val stopID: String,
+    val lat: Double,
+    val long: Double
+)

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Stop.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Stop.kt
@@ -2,7 +2,6 @@ package com.example.ithaca_transit_android_v2.models
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
-// TODO: deprecate this class 
 data class Stop(
     val stopID: String,
     val lat: Double,

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/models/Stop.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/models/Stop.kt
@@ -1,7 +1,6 @@
 package com.example.ithaca_transit_android_v2.models
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-//Location. - Represents either a bus stop or a google place.
 @JsonClass(generateAdapter = true)
 // TODO: deprecate this class 
 data class Stop(


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Justin, Lesley, Aastha, and I finished route networking. 


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
**Made route networking work**
 - `getRouteOptions` forms queries when passed in parameters ` start`, `end`, `time`, `arriveBy`, `destinationName`
 - `getRouteOptions` then gets data from the backend and parses the data, ultimately returns a `RouteOptions` object

**Simplified networking code**
- Instead of having many different adapters for each sub-data type, now we only have a `RouteAdapter` and an adapter for parsing a date string into a `Date` object.

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
We ran the code with parameters simulating a real query and got correct output displayed in Logcat.




## Related PRs or Issues (delete if not applicable)
This PR is an update to my old PR https://github.com/cuappdev/ithaca-transit-android-v2/pull/21
