### PR TITLE
Reset map zoom to start of selected route

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,5 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
 
     implementation 'com.google.android.material:material:1.2.1'
-    implementation 'com.google.android.material:material:1.0.0'
 
 }

--- a/app/src/main/java/com/example/ithaca_transit_android_v2/Repository.kt
+++ b/app/src/main/java/com/example/ithaca_transit_android_v2/Repository.kt
@@ -1,11 +1,20 @@
 package com.example.ithaca_transit_android_v2
 
+import com.example.ithaca_transit_android_v2.models.Coordinate
 import com.example.ithaca_transit_android_v2.models.Location
+import com.example.ithaca_transit_android_v2.models.LocationType
 import com.example.ithaca_transit_android_v2.models.Route
 
 object Repository {
     init {
     }
+    // this sets the location to the middle of Cornell's campus
+    var defaultLocation = Location(
+        type = LocationType.APPLE_PLACE,
+        name = "Cornell",
+        coordinate = Coordinate(42.4491, -76.4833),
+        detail = "default location for map zoom")
+
     var currentLocation: android.location.Location? = null
     var startLocation: Location? = null
     var destinationLocation: Location? = null


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- When a route is selected, the map will zoom to the start of the route instead of staying static. If the app does not have access to the start of the route for any reason, it will zoom to the default location (middle of cornell) 
- Made a variable in `Repository` for the default location for clarity 
- Cleaned up `MapPresenter` file and reduce redundancy in code

